### PR TITLE
Update FillablePDF#save to use FileUtils.mv

### DIFF
--- a/lib/fillable-pdf.rb
+++ b/lib/fillable-pdf.rb
@@ -1,5 +1,6 @@
 require_relative 'fillable-pdf/itext'
 require_relative 'field'
+require 'fileutils'
 require 'securerandom'
 
 class FillablePDF
@@ -158,7 +159,7 @@ class FillablePDF
   def save(flatten: false)
     tmp_file = SecureRandom.uuid
     save_as(tmp_file, flatten: flatten)
-    File.rename tmp_file, @file_path
+    FileUtils.mv tmp_file, @file_path
   end
 
   ##


### PR DESCRIPTION
This is instead of File.rename, which can error out with
"Invalid cross-device link @ rb_file_s_rename" in e.g.
Docker containers.