### PR TITLE
Change the path for temporary files to use the OS default.

### DIFF
--- a/lib/fillable-pdf.rb
+++ b/lib/fillable-pdf.rb
@@ -1,8 +1,8 @@
 require_relative 'fillable-pdf/itext'
 require_relative 'field'
 require 'base64'
-require 'fileutils'
 require 'securerandom'
+require 'tmpdir'
 
 class FillablePDF # rubocop:disable Metrics/ClassLength
   ##
@@ -148,7 +148,7 @@ class FillablePDF # rubocop:disable Metrics/ClassLength
   #   @param [String|Symbol] base64_image_data base64 encoded data image
   #
   def set_image_base64(key, base64_image_data)
-    tmp_file = SecureRandom.uuid
+    tmp_file = "#{Dir.tmpdir}/#{SecureRandom.uuid}"
     File.binwrite(tmp_file, Base64.decode64(base64_image_data))
     set_image(key, tmp_file)
   ensure
@@ -214,7 +214,7 @@ class FillablePDF # rubocop:disable Metrics/ClassLength
   #   @param [bool] flatten true if PDF should be flattened, false otherwise
   #
   def save(flatten: false)
-    tmp_file = SecureRandom.uuid
+    tmp_file = "#{Dir.tmpdir}/#{SecureRandom.uuid}"
     save_as(tmp_file, flatten: flatten)
     FileUtils.mv tmp_file, @file_path
   end

--- a/lib/fillable-pdf/version.rb
+++ b/lib/fillable-pdf/version.rb
@@ -1,3 +1,3 @@
 class FillablePDF
-  VERSION = '0.9.5.1'
+  VERSION = '0.9.5.2'
 end


### PR DESCRIPTION
Previously, all temporary files would be briefly created within the same directory as the original PDF file and destroyed shortly after. This did not work on read-only file systems, such as the ones provided by AWS lambda. Now all temporary files are stored in a directory that is defined by the operating system, which is writeable in AWS Lambda.