### PR TITLE
Move #suppress_warnings to a namespaced Module

### DIFF
--- a/lib/fillable-pdf.rb
+++ b/lib/fillable-pdf.rb
@@ -1,10 +1,13 @@
 require_relative 'fillable-pdf/itext'
+require_relative 'fillable-pdf/suppress_warnings'
 require_relative 'field'
 require 'base64'
 require 'securerandom'
 require 'tmpdir'
 
 class FillablePDF # rubocop:disable Metrics/ClassLength
+  include SuppressWarnings
+
   ##
   # Opens a given fillable-pdf PDF file and prepares it for modification.
   #

--- a/lib/fillable-pdf/itext.rb
+++ b/lib/fillable-pdf/itext.rb
@@ -1,9 +1,11 @@
-require_relative 'kernel'
+require_relative 'suppress_warnings'
 require 'rjb'
 
 Rjb.load(Dir.glob(File.expand_path('../../ext/*.jar', __dir__)).join(':'))
 
 module ITEXT
+  extend FillablePDF::SuppressWarnings
+
   suppress_warnings do
     ByteArrayOutputStream = Rjb.import 'com.itextpdf.io.source.ByteArrayOutputStream'
     Canvas = Rjb.import 'com.itextpdf.layout.Canvas'

--- a/lib/fillable-pdf/kernel.rb
+++ b/lib/fillable-pdf/kernel.rb
@@ -1,9 +1,0 @@
-module Kernel
-  def suppress_warnings
-    original_verbosity = $VERBOSE
-    $VERBOSE = nil
-    result = yield
-    $VERBOSE = original_verbosity
-    result
-  end
-end

--- a/lib/fillable-pdf/suppress_warnings.rb
+++ b/lib/fillable-pdf/suppress_warnings.rb
@@ -1,0 +1,11 @@
+class FillablePDF
+  module SuppressWarnings
+    def suppress_warnings
+      original_verbosity = $VERBOSE
+      $VERBOSE = nil
+      result = yield
+      $VERBOSE = original_verbosity
+      result
+    end
+  end
+end


### PR DESCRIPTION
Adding methods to Kernel is likely to break apps, so we should scope it to this gem only.