### PR TITLE
Run lint on pushes to main and fix Gemfile comment

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in cloudflare-turnstile-rails.gemspec
+# Specify your gem's dependencies in fillable-pdf.gemspec
 gemspec
 
 # A Ruby library for testing your library against different versions of dependencies

--- a/README.md
+++ b/README.md
@@ -191,10 +191,10 @@ An instance of `FillablePDF` has the following methods at its disposal:
     # output example: '/Btn'
 
     # list of all field types
-    FillablePDF::Field::BUTTON ('/Btn')
-    FillablePDF::Field::CHOICE ('/Ch')
-    FillablePDF::Field::SIGNATURE ('/Sig')
-    FillablePDF::Field::TEXT ('/Tx')
+    FillablePDF::Field::BUTTON # => '/Btn'
+    FillablePDF::Field::CHOICE # => '/Ch'
+    FillablePDF::Field::SIGNATURE # => '/Sig'
+    FillablePDF::Field::TEXT # => '/Tx'
     ```
 
     You can check the field type by using:


### PR DESCRIPTION
The lint workflow still watched the old master branch, so it never ran on direct pushes after the rename to main. Also corrects a stray comment that referenced the wrong project's gemspec.